### PR TITLE
Use https for nbviewer.org render

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The notebooks contain exercises but you will need to enable the [exercise2 exten
 
 Instructors are welcome to contact dkirkby at uci.edu for access to additional material or to discuss collaboration.
 
-[![license](https://img.shields.io/github/license/dkirkby/MachineLearningStatistics.svg)]() [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/Contents.ipynb)
+[![license](https://img.shields.io/github/license/dkirkby/MachineLearningStatistics.svg)]() [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](https://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/Contents.ipynb)


### PR DESCRIPTION
hey! just found your repo when looking up how to add a "render with nbviewer" for my own machine learning repo, [grisaitis/graphical-models](https://github.com/grisaitis/graphical-models) 😎

i noticed you had `http` in your badge URL, hence this small fix. 